### PR TITLE
Move App component into its own file

### DIFF
--- a/node-webpack.config.mjs
+++ b/node-webpack.config.mjs
@@ -95,25 +95,7 @@ export default function createConfigs(_env, argv) {
     module: {
       rules: [
         {
-          // Option 1, fails at request time with Error: Could not find the module "./src/components/counter.tsx" in the React SSR Manifest.
-          // The generated server-bundle.js contains two copies of counter.tsx, named
-          //   (react-server)/./src/components/counter.tsx?9a1f
-          // and
-          //   (react-server)/./src/components/counter.tsx?2188
-          // which therefore causes dist/react-ssr-manifest to be missing the module information
-          //resource: [/\/server\/rsc\//, /\/components\/.*/],
-
-          // Option 2, fails at request time with TypeError: Cannot read properties of null (reading 'useState')
-          // and ReferenceError: React is not defined
-          // The generated server-bundle.js contains two copies of counter.tsx, named
-          //   ./src/components/counter.tsx
-          // and
-          //   (react-server)/./src/components/counter.tsx
-          resource: [/\/server\/rsc\//, /\/components\/Layout\.tsx/],
-
-          // Option 3, fails to compile with Error: react-dom/server is not supported in React Server Components.
-          //resource: [/\/server\/rsc\//, /\/components\/.*/, /routes\.tsx/],
-
+          resource: [/\/server\/rsc\//, /\/components\/App\.tsx/],
           layer: webpackRscLayerName,
         },
         {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Layout from "./Layout";
+import {Counter} from "./counter";
+
+export function App() {
+  return (
+    <Layout>
+      <div>Hello world</div>
+      <Counter />
+    </Layout>
+  );
+}

--- a/src/components/counter.tsx
+++ b/src/components/counter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 export const Counter = () => {
   const [count, setCount] = useState(0);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -24,9 +24,8 @@ import {
 
 //console.log("manifests", manifests);
 
-import Layout from "./components/Layout";
-import { Counter } from "./components/counter";
-import { Url } from "url";
+import {Url} from "url";
+import {App} from "./components/App";
 
 export function getUiRouter() {
   const router = Router();
@@ -43,14 +42,6 @@ export function getUiRouter() {
   router.post("/", async (req, res, next) => { await handlePost(req, res, next); });
 
   return router;
-}
-
-function App() {
-  return (
-    <Layout>
-      <div>Hello world</div>
-      <Counter />
-    </Layout>);
 }
 
 const oneDay = 60 * 60 * 24;


### PR DESCRIPTION
This is required so that we can configure the webpack layer rule to include the main server component in the RSC layer.