### PR TITLE
Fix `Link` import

### DIFF
--- a/node-webpack.config.mjs
+++ b/node-webpack.config.mjs
@@ -117,6 +117,15 @@ export default function createConfigs(_env, argv) {
               test: /\.tsx?$/,
               use: [rscSsrLoader, serverSwcLoader],
             },
+            {
+              issuerLayer: webpackRscLayerName,
+              test: /\.m?jsx?$/,
+              use: rscServerLoader,
+            },
+            {
+              test: /\.m?jsx?$/,
+              use: rscSsrLoader,
+            },
           ],
         },
         // TODO: support importing other kinds of assets, and aliases for
@@ -180,6 +189,10 @@ export default function createConfigs(_env, argv) {
         {
           test: /\.tsx?$/,
           use: [rscClientLoader, 'swc-loader'],
+        },
+        {
+          test: /\.m?jsx?$/,
+          use: rscClientLoader,
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mfng-repro",
       "version": "0.0.1",
       "dependencies": {
-        "@mfng/core": "^4.1.3",
+        "@mfng/core": "^4.1.4",
         "cookie-parser": "^1.4.6",
         "express": "^4.19.2",
         "morgan": "^1.10.0",
@@ -19,7 +19,7 @@
         "react-server-dom-webpack": "^19.0.0-beta-6946ebe620-20240508"
       },
       "devDependencies": {
-        "@mfng/webpack-rsc": "^4.0.1",
+        "@mfng/webpack-rsc": "^4.1.0",
         "@swc/cli": "^0.3.12",
         "@swc/core": "^1.4.16",
         "@types/cookie-parser": "^1.4.7",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@mfng/webpack-rsc": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@mfng/webpack-rsc/-/webpack-rsc-4.0.1.tgz",
-      "integrity": "sha512-ueObgKTlNqHbR6FllipITAha7fVzOMHDvyK59h2WU6u3DIBs0+Lwz0cSiU7PKnrBhxxTApRaL5zS5krrYy9aog==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@mfng/webpack-rsc/-/webpack-rsc-4.1.0.tgz",
+      "integrity": "sha512-oYe5yoTYMHbGA3/ZwQLhamWQ1aMNF2dtdY3E1pK7uv6UsiJrutI27XRknA6uMbfMDfMD/ay82Gfnih5J6cRAdg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.21.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react-server-dom-webpack": "^19.0.0-beta-6946ebe620-20240508"
   },
   "devDependencies": {
-    "@mfng/webpack-rsc": "^4.0.1",
+    "@mfng/webpack-rsc": "^4.1.0",
     "@swc/cli": "^0.3.12",
     "@swc/core": "^1.4.16",
     "@types/cookie-parser": "^1.4.7",


### PR DESCRIPTION
This includes two fixes:
- [Include JS files in RSC loaders](https://github.com/quentinmit/mfng-repro/commit/23d1a7d70fafd2a4acae46b9f2501d6bddf651ea) – This is required to import client components from third-party libs, e.g. `Link` from `@mfng/core/client`. I've also updated the README at https://www.npmjs.com/package/@mfng/webpack-rsc accordingly.
- [Update @mfng/webpack-rsc](https://github.com/quentinmit/mfng-repro/commit/273302cd2099185eaecbd864cd37d757f4b7a49d)  – This includes support for parsing  import assertions, as used in `manifests.js`.